### PR TITLE
[gd_post_badge] now supports past, ongoing, upcoming conditions for events - ADDED

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -27,6 +27,9 @@ It's easy to sort events by selecting "upcoming," "today," "past" or "all" and d
 
 == Changelog ==
 
+= 2.1.0.2 =
+* [gd_post_badge] now supports past, ongoing, upcoming conditions for events - ADDED
+
 = 2.1.0.1 =
 * Change Jquery doc ready to pure JS doc ready so jQuery can be loaded without render blocking  - CHANGED
 * Shows incorrect start time & end time with bootstrap style - FIXED


### PR DESCRIPTION
Examples:

```
[gd_post_badge key="event_dates" condition="is_past_event" badge="PAST EVENT"]
[gd_post_badge key="event_dates" condition="is_ongoing_event" badge="ONGOING EVENT"]
[gd_post_badge key="event_dates" condition="is_upcoming_event" badge="UPCOMING EVENT"]
```

is_past_event, is_ongoing_event & is_upcoming_event can be used on any event field.

Example:
`[gd_post_badge key="phone" condition="is_upcoming_event" badge="%%input%%"]`